### PR TITLE
js-style-kit: add prettier-plugin-css-order and update config

### DIFF
--- a/.changeset/tough-crabs-float.md
+++ b/.changeset/tough-crabs-float.md
@@ -1,0 +1,5 @@
+---
+"js-style-kit": patch
+---
+
+Add prettier-plugin-css-order

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/drake-nathan/js-style-kit?labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit%20Reviews)
+
 # JS Style Kit
 
 A zero-configuration ESLint and Prettier toolkit for JavaScript and TypeScript projects.

--- a/apps/docs/src/components/HomepageFeatures/styles.module.css
+++ b/apps/docs/src/components/HomepageFeatures/styles.module.css
@@ -6,6 +6,6 @@
 }
 
 .featureSvg {
-  height: 200px;
   width: 200px;
+  height: 200px;
 }

--- a/apps/docs/src/pages/index.module.css
+++ b/apps/docs/src/pages/index.module.css
@@ -4,10 +4,10 @@
  */
 
 .heroBanner {
-  padding: 4rem 0;
-  text-align: center;
   position: relative;
+  padding: 4rem 0;
   overflow: hidden;
+  text-align: center;
 }
 
 @media screen and (max-width: 996px) {
@@ -18,6 +18,6 @@
 
 .buttons {
   display: flex;
-  align-items: center;
   justify-content: center;
+  align-items: center;
 }

--- a/packages/style-kit/README.md
+++ b/packages/style-kit/README.md
@@ -1,3 +1,5 @@
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/drake-nathan/js-style-kit?labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit%20Reviews)
+
 # `js-style-kit`
 
 A zero-configuration style guide for ESLint and Prettier that provides sensible default settings and flexible configuration options.

--- a/packages/style-kit/README.md
+++ b/packages/style-kit/README.md
@@ -204,6 +204,7 @@ import { prettierConfig } from "js-style-kit";
 
 export default prettierConfig({
   // All options shown with their default values
+  cssOrderPlugin: true, // Enable CSS order plugin
   jsonSortPlugin: true, // Enable JSON sorting plugin
   packageJsonPlugin: true, // Enable package.json sorting plugin
   tailwindPlugin: false, // Enable Tailwind CSS plugin (boolean, string[], or options object)
@@ -231,6 +232,15 @@ tailwindPlugin: {
   tailwindFunctions: ["clsx", "cva", "myCustomFunction"],
   tailwindAttributes: ["tw"]
 }
+```
+
+#### CSS Order Plugin
+
+The CSS order plugin is enabled by default. It sorts CSS properties in a consistent order. You can disable it:
+
+```js
+// Disable CSS order plugin
+cssOrderPlugin: false;
 ```
 
 #### JSON Sorting
@@ -303,6 +313,7 @@ import { prettierConfig } from "js-style-kit";
 
 export default prettierConfig({
   tailwindPlugin: true,
+  cssOrderPlugin: true,
   printWidth: 100,
   singleQuote: true,
 });

--- a/packages/style-kit/package.json
+++ b/packages/style-kit/package.json
@@ -43,6 +43,7 @@
     "globals": "^16.0.0",
     "is-type-of": "^2.2.0",
     "prettier": "^3.5.3",
+    "prettier-plugin-css-order": "^2.1.2",
     "prettier-plugin-packagejson": "^2.5.10",
     "prettier-plugin-sort-json": "^4.1.1",
     "prettier-plugin-tailwindcss": "^0.6.11",

--- a/packages/style-kit/src/prettier/index.test.ts
+++ b/packages/style-kit/src/prettier/index.test.ts
@@ -12,7 +12,11 @@ describe("prettierConfig", () => {
     expect(config).toEqual({
       experimentalTernaries: true,
       jsonRecursiveSort: true,
-      plugins: ["prettier-plugin-sort-json", "prettier-plugin-packagejson"],
+      plugins: [
+        "prettier-plugin-css-order",
+        "prettier-plugin-sort-json",
+        "prettier-plugin-packagejson",
+      ],
     });
   });
 
@@ -114,5 +118,17 @@ describe("prettierConfig", () => {
     });
     expect(config.tailwindFunctions).toEqual(["clsx", "cva", "cn"]);
     expect(config.tabWidth).toBe(2);
+  });
+
+  it("should include css order plugin by default", () => {
+    const config = prettierConfig();
+
+    expect(config.plugins).toContain("prettier-plugin-css-order");
+  });
+
+  it("should disable css order plugin when specified", () => {
+    const config = prettierConfig({ cssOrderPlugin: false });
+
+    expect(config.plugins).not.toContain("prettier-plugin-css-order");
   });
 });

--- a/packages/style-kit/src/prettier/index.ts
+++ b/packages/style-kit/src/prettier/index.ts
@@ -20,10 +20,10 @@ export interface PrettierConfigWithPlugins
  * Creates a Prettier configuration object with optional Tailwind support
  *
  * @param options - Configuration options for Prettier
- * @param options.cssOrder CSS order sorting support
- * @param options.jsonSort JSON sorting support
- * @param options.packageJson Package.json sorting support
- * @param options.tailwind Tailwind CSS formatting support
+ * @param options.cssOrderPlugin CSS order sorting support
+ * @param options.jsonSortPlugin JSON sorting support
+ * @param options.packageJsonPlugin Package.json sorting support
+ * @param options.tailwindPlugin Tailwind CSS formatting support
  * @returns Prettier configuration object with:
  * - Default Prettier configuration
  * - Experimental ternaries enabled

--- a/packages/style-kit/src/prettier/index.ts
+++ b/packages/style-kit/src/prettier/index.ts
@@ -5,6 +5,7 @@ import type { PluginOptions as TailwindPluginOptions } from "prettier-plugin-tai
 import { isArray, isObject } from "is-type-of";
 
 interface PrettierConfigOptions extends PrettierConfig {
+  cssOrderPlugin?: boolean;
   jsonSortPlugin?: boolean | SortJsonPluginOptions;
   packageJsonPlugin?: boolean;
   tailwindPlugin?: boolean | string[] | TailwindPluginOptions;
@@ -19,12 +20,14 @@ export interface PrettierConfigWithPlugins
  * Creates a Prettier configuration object with optional Tailwind support
  *
  * @param options - Configuration options for Prettier
- * @param options.tailwind Tailwind CSS formatting support
+ * @param options.cssOrder CSS order sorting support
  * @param options.jsonSort JSON sorting support
  * @param options.packageJson Package.json sorting support
+ * @param options.tailwind Tailwind CSS formatting support
  * @returns Prettier configuration object with:
  * - Default Prettier configuration
  * - Experimental ternaries enabled
+ * - CSS order plugin
  * - JSON sorting plugin
  * - Package.json sorting plugin
  * - Optional Tailwind plugin and functions
@@ -33,6 +36,7 @@ export const prettierConfig = (
   options: PrettierConfigOptions = {},
 ): PrettierConfigWithPlugins => {
   const {
+    cssOrderPlugin = true,
     jsonSortPlugin = true,
     packageJsonPlugin = true,
     tailwindPlugin = false,
@@ -44,6 +48,10 @@ export const prettierConfig = (
     experimentalTernaries: true,
     ...rest,
   };
+
+  if (cssOrderPlugin) {
+    plugins.push("prettier-plugin-css-order");
+  }
 
   if (jsonSortPlugin) {
     plugins.push("prettier-plugin-sort-json");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
+      prettier-plugin-css-order:
+        specifier: ^2.1.2
+        version: 2.1.2(postcss@8.5.1)(prettier@3.5.3)
       prettier-plugin-packagejson:
         specifier: ^2.5.10
         version: 2.5.10(prettier@3.5.3)
@@ -13466,7 +13469,6 @@ snapshots:
   postcss-less@6.0.0(postcss@8.5.1):
     dependencies:
       postcss: 8.5.1
-    optional: true
 
   postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.1)(yaml@2.7.0):
     dependencies:
@@ -13727,7 +13729,6 @@ snapshots:
   postcss-scss@4.0.9(postcss@8.5.1):
     dependencies:
       postcss: 8.5.1
-    optional: true
 
   postcss-selector-not@8.0.1(postcss@8.5.1):
     dependencies:
@@ -13782,7 +13783,6 @@ snapshots:
       prettier: 3.5.3
     transitivePeerDependencies:
       - postcss
-    optional: true
 
   prettier-plugin-packagejson@2.5.10(prettier@3.5.3):
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration option to enable or disable automatic sorting of CSS properties, enhancing code styling consistency and maintainability.
  - Added the `prettier-plugin-css-order` to improve CSS property organization.

- **Style**
  - Reordered CSS declarations in various style files for improved consistency while maintaining the visual design.

- **Documentation**
  - Updated README to include a new configuration option and its default behavior for the CSS order plugin.
  - Added a badge for CodeRabbit pull request review status to the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->