### PR TITLE
Disable react refresh by default

### DIFF
--- a/.changeset/ninety-donkeys-wink.md
+++ b/.changeset/ninety-donkeys-wink.md
@@ -1,0 +1,5 @@
+---
+"js-style-kit": patch
+---
+
+disable react refresh by default

--- a/docs/docs/react-config.mdx
+++ b/docs/docs/react-config.mdx
@@ -124,15 +124,15 @@ export default eslintConfig({
 
 [React Fast Refresh](https://www.npmjs.com/package/react-refresh) is a feature that provides instant feedback on component changes without losing component state. JS Style Kit includes support for validating that your components can safely be updated with Fast Refresh through the `eslint-plugin-react-refresh` plugin.
 
-React Fast Refresh validation is **enabled by default** when React support is enabled. To explicitly control it:
+React Fast Refresh validation is **disabled by default**. It should be enabled for SPAs like Vite. It should be left disabled for Next.js projects. To enable it:
 
 ```js
 import { eslintConfig } from "js-style-kit";
 
 export default eslintConfig({
   react: {
-    // Disable React Fast Refresh validation
-    reactRefresh: false,
+    // Enable React Fast Refresh validation
+    reactRefresh: true,
   },
 });
 ```

--- a/packages/style-kit/README.md
+++ b/packages/style-kit/README.md
@@ -131,7 +131,7 @@ react: true
 // you can also pass an object to control react compiler and next support
 react: {
   reactCompiler: false,
-  reactRefresh: false, // Controls React Fast Refresh validation (default: true when react is enabled)
+  reactRefresh: false, // Controls React Fast Refresh validation (disabled by default)
   next: true
 }
 // next simply adds ".next" to the ignores array, but I plan add the next plugin in the future

--- a/packages/style-kit/src/eslint/index.test.ts
+++ b/packages/style-kit/src/eslint/index.test.ts
@@ -111,24 +111,24 @@ describe("eslintConfig", () => {
       );
     });
 
-    it("includes React Refresh config by default when React is enabled", () => {
+    it("excludes React Refresh config by default when React is enabled", () => {
       const config = eslintConfig({ react: true });
-
-      expect(config.some((c) => c.name === configNames.reactRefresh)).toBe(
-        true,
-      );
-    });
-
-    it("excludes React Refresh config when React is enabled but React Refresh is not", () => {
-      const config = eslintConfig({ react: { reactRefresh: false } });
 
       expect(config.some((c) => c.name === configNames.reactRefresh)).toBe(
         false,
       );
     });
 
+    it("includes React Refresh config when React is enabled and React Refresh is explicitly enabled", () => {
+      const config = eslintConfig({ react: { reactRefresh: true } });
+
+      expect(config.some((c) => c.name === configNames.reactRefresh)).toBe(
+        true,
+      );
+    });
+
     it("applies correct React Refresh rules when enabled", () => {
-      const config = eslintConfig({ react: true });
+      const config = eslintConfig({ react: { reactRefresh: true } });
       const reactRefreshConfig = config.find(
         (c) => c.name === configNames.reactRefresh,
       );

--- a/packages/style-kit/src/eslint/index.ts
+++ b/packages/style-kit/src/eslint/index.ts
@@ -118,9 +118,9 @@ export const eslintConfig = (
       configs.push(reactCompilerEslintConfig);
     }
 
-    // Apply reactRefresh by default if react is true or if react.reactRefresh isn't explicitly false
+    // Apply reactRefresh only if explicitly enabled via react.reactRefresh = true
     const shouldUseReactRefresh =
-      react === true || (isObject(react) && react.reactRefresh !== false);
+      isObject(react) && react.reactRefresh === true;
 
     if (shouldUseReactRefresh) {
       configs.push(reactRefreshEslintConfig());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The React development environment now has React Fast Refresh disabled by default. Developers must explicitly enable it when needed.
  
- **Documentation**
	- Updated guidance clarifies the revised default behavior for React Fast Refresh, with specific recommendations for different project types such as single page applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->